### PR TITLE
SYS-1060: Rename API class to match PEP standards

### DIFF
--- a/alma_api_client.py
+++ b/alma_api_client.py
@@ -2,7 +2,7 @@ import requests
 from time import sleep
 
 
-class Alma_Api_Client:
+class AlmaAPIClient:
     def __init__(self, api_key: str) -> None:
         self.API_KEY = api_key
         self.BASE_URL = "https://api-na.hosted.exlibrisgroup.com"

--- a/create_items.py
+++ b/create_items.py
@@ -4,7 +4,7 @@ import sys
 import pprint as pp
 
 from alma_api_keys import API_KEYS
-from alma_api_client import Alma_Api_Client
+from alma_api_client import AlmaAPIClient
 
 
 def _has_items(bib_id, holding_id):
@@ -35,7 +35,7 @@ def _format_item(item_data):
 
 
 if __name__ == "__main__":
-    alma = Alma_Api_Client(API_KEYS["DIIT_SCRIPTS"])
+    alma = AlmaAPIClient(API_KEYS["DIIT_SCRIPTS"])
     # Values for creating items
     # TODO: Pass to program via files
     # CLARK0099066 is the last assigned barcode, via ALMA-42

--- a/get_analytics_report.py
+++ b/get_analytics_report.py
@@ -4,7 +4,7 @@ import xmltodict
 import pprint as pp
 
 from alma_api_keys import API_KEYS
-from alma_api_client import Alma_Api_Client
+from alma_api_client import AlmaAPIClient
 
 
 def get_real_column_names(report_json):
@@ -103,7 +103,7 @@ def get_report_data(report):
 
 
 def run_report():
-    alma = Alma_Api_Client(API_KEYS["DIIT_ANALYTICS"])
+    alma = AlmaAPIClient(API_KEYS["DIIT_ANALYTICS"])
     report_path = "/shared/University of California Los Angeles (UCLA) 01UCS_LAL/Cataloging/Reports/API/Cataloging Statistics (API)"
     # From form
     yyyymm = "20220406"

--- a/get_vendor_data.py
+++ b/get_vendor_data.py
@@ -1,9 +1,9 @@
 from csv import DictWriter
 from alma_api_keys import API_KEYS
-from alma_api_client import Alma_Api_Client
+from alma_api_client import AlmaAPIClient
 
 
-def get_active_vendor_codes(alma_client: type[Alma_Api_Client]) -> list:
+def get_active_vendor_codes(alma_client: type[AlmaAPIClient]) -> list:
     vendor_codes: list = []
     vendor_total: int = -1
     # Max limit (records per batch) is 100
@@ -60,7 +60,7 @@ def get_email_address(vendor: dict) -> str:
     return email_address
 
 
-def get_vendor_data(alma_client: type[Alma_Api_Client], vendor_codes: list) -> list:
+def get_vendor_data(alma_client: type[AlmaAPIClient], vendor_codes: list) -> list:
     # Returns a list of dictionaries, one for each vendor code
     vendor_data: list = []
     for vendor_code in vendor_codes:
@@ -86,7 +86,7 @@ def get_vendor_data(alma_client: type[Alma_Api_Client], vendor_codes: list) -> l
 
 
 def main() -> None:
-    alma_client = Alma_Api_Client(API_KEYS["DIIT_SCRIPTS"])
+    alma_client = AlmaAPIClient(API_KEYS["DIIT_SCRIPTS"])
     vendor_codes = get_active_vendor_codes(alma_client)
     vendor_data = get_vendor_data(alma_client, vendor_codes)
     column_headers = vendor_data[0].keys()

--- a/process_invoices.py
+++ b/process_invoices.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-from alma_api_client import Alma_Api_Client
+from alma_api_client import AlmaAPIClient
 from alma_api_keys import API_KEYS
 from datetime import datetime
 from invoice import Invoice
@@ -174,7 +174,7 @@ def create_pac_invoices(xml_file, dump_dict):
 
 def get_xml_from_alma():
     global client
-    client = Alma_Api_Client(API_KEYS["DIIT_SCRIPTS"])
+    client = AlmaAPIClient(API_KEYS["DIIT_SCRIPTS"])
     profile_id = get_invoice_profile_id()
     job_id = get_invoice_job_id(profile_id)
     instance_id = run_job(job_id)


### PR DESCRIPTION
Part of [SYS-1060](https://jira.library.ucla.edu/browse/SYS-1060).

Renames class from `Alma_Api_Client` to `AlmaAPIClient` to comply with [PEP 8 class naming convention](https://peps.python.org/pep-0008/#class-names).

Updates all programs using this class accordingly.
