### PR TITLE
SYS-1062: Add API method to retrieve specific Alma bib record

### DIFF
--- a/alma_api_client.py
+++ b/alma_api_client.py
@@ -151,3 +151,9 @@ class AlmaAPIClient:
             parameters = {}
         api = f"/almaws/v1/acq/vendors/{vendor_code}"
         return self._call_get_api(api, parameters)
+
+    def get_bib(self, mms_id: str, parameters: dict = None) -> dict:
+        if parameters is None:
+            parameters = {}
+        api = f"/almaws/v1/bibs/{mms_id}"
+        return self._call_get_api(api, parameters)


### PR DESCRIPTION
Implements [SYS-1062](https://jira.library.ucla.edu/browse/SYS-1062)

Adds a simple method to get a single bib record. Works with or without optional query string parameters (view = full, brief, local_fields; expand = p_avail, e_avail, d_avail, requests).