### PR TITLE
SYS-1063: Add API method to update Alma bib records

### DIFF
--- a/alma_api_client.py
+++ b/alma_api_client.py
@@ -54,7 +54,7 @@ class AlmaAPIClient:
         response = requests.post(
             post_url, headers=headers, json=data, params=parameters
         )
-        api_data: dict = self._get_api_data(response)
+        api_data: dict = self._get_api_data(response, format)
         return api_data
 
     def _call_put_api(
@@ -82,7 +82,7 @@ class AlmaAPIClient:
             print(response.headers)
             print(response.text)
             # exit(1)
-        api_data: dict = self._get_api_data(response)
+        api_data: dict = self._get_api_data(response, format)
         return api_data
 
     def create_item(


### PR DESCRIPTION
Implements [SYS-1063](https://jira.library.ucla.edu/browse/SYS-1063).  Includes code from both @ztucker4 and @akohler .

This PR implements an `update_bib()` API method for updating Alma bib records.  This required some internal changes to the class:
* Request headers are now format-specific, depending on `json` (the default) or `xml`
* Internal request handlers (`_call_get_api()`, etc.) are now nominally format-aware
  * POST and DELETE requests are currently used only by JSON APIs
  * PUT requests are currently used only by XML-only APIs
* XML response data from XML-only APIs is returned as `bytes` data in the method's `dict["content"]` return value.
```
# Assuming client is an initialized AlmaAPIClient
>>> api_data = client.get_bib(mms_id)
>>> type(api_data["content"])
<class 'bytes'>
```

None of the class's existing public method signatures, including initialization, have changed.  I tested several programs which use various existing public API methods, with no errors.

My experimental script for playing with our Alma bib APIs and `pymarc`: https://gist.github.com/akohler/cb5403d9a6ae4a365e3eeea16b0eecc4
