### PR TITLE
SYS-1074: Convert between Alma Bib XML and MARCXML

### DIFF
--- a/alma_marc.py
+++ b/alma_marc.py
@@ -3,7 +3,7 @@ from pymarc import parse_xml_to_array, record_to_xml_node, Record
 from io import BytesIO
 
 
-def get_record_from_bib(alma_bib: bytes) -> Record:
+def get_pymarc_record_from_bib(alma_bib: bytes) -> Record:
     """Takes an Alma Bib and returns a pymarc Record containing <record> content."""
     root = ET.fromstring(alma_bib)
     record = root.find("record")
@@ -16,7 +16,7 @@ def get_record_from_bib(alma_bib: bytes) -> Record:
     return pymarc_record
 
 
-def update_alma_bib_record(original_bib: bytes, new_record: Record) -> bytes:
+def prepare_bib_for_update(original_bib: bytes, new_record: Record) -> bytes:
     """Takes an Alma Bib and a pymarc Record and returns an updated Bib bytestring
     containing data from the new Record in the <record> element."""
     # convert Bib and Record to ET Elements,

--- a/alma_marc.py
+++ b/alma_marc.py
@@ -1,0 +1,26 @@
+import xml.etree.ElementTree as ET
+
+
+def get_MARCXML_from_bib(alma_bib: bytes) -> bytes:
+    """Takes an Alma Bib and returns only the MARCXML content as a bytestring."""
+    root = ET.fromstring(alma_bib)
+    record = root.find("record")
+    marc_xml = ET.tostring(record, encoding="utf8", method="xml", xml_declaration=False)
+    return marc_xml
+
+
+def update_alma_bib_xml(orig_bib: bytes, new_record: bytes) -> bytes:
+    """Takes an Alma Bib and a MARCXML Record and returns an updated Bib bytestring
+    containing the new Record."""
+    bib_element = ET.fromstring(orig_bib)
+    record_element = ET.fromstring(new_record)
+    old_record = bib_element.find("record")
+    bib_element.remove(old_record)
+    bib_element.append(record_element)
+
+    # xml_declaration=False because the Update Bib API doesn't require it, and the API
+    # call fails if xml_declaration=True due to escape characters in ET's declaration
+    bib_xml = ET.tostring(
+        bib_element, encoding="utf8", method="xml", xml_declaration=False
+    )
+    return bib_xml

--- a/alma_marc.py
+++ b/alma_marc.py
@@ -1,22 +1,32 @@
 import xml.etree.ElementTree as ET
+from pymarc import parse_xml_to_array, record_to_xml_node, Record
+from io import BytesIO
 
 
-def get_MARCXML_from_bib(alma_bib: bytes) -> bytes:
-    """Takes an Alma Bib and returns only the MARCXML content as a bytestring."""
+def get_record_from_bib(alma_bib: bytes) -> Record:
+    """Takes an Alma Bib and returns a pymarc Record containing <record> content."""
     root = ET.fromstring(alma_bib)
     record = root.find("record")
+
+    # xml_declaration=False since we want only the <record> element, not a full XML doc
     marc_xml = ET.tostring(record, encoding="utf8", method="xml", xml_declaration=False)
-    return marc_xml
+    # pymarc needs file-like object
+    with BytesIO(marc_xml) as fh:
+        pymarc_record = parse_xml_to_array(fh)[0]
+    return pymarc_record
 
 
-def update_alma_bib_xml(orig_bib: bytes, new_record: bytes) -> bytes:
-    """Takes an Alma Bib and a MARCXML Record and returns an updated Bib bytestring
-    containing the new Record."""
-    bib_element = ET.fromstring(orig_bib)
-    record_element = ET.fromstring(new_record)
-    old_record = bib_element.find("record")
-    bib_element.remove(old_record)
-    bib_element.append(record_element)
+def update_alma_bib_record(original_bib: bytes, new_record: Record) -> bytes:
+    """Takes an Alma Bib and a pymarc Record and returns an updated Bib bytestring
+    containing data from the new Record in the <record> element."""
+    # convert Bib and Record to ET Elements,
+    # using pymarc's record_to_xml_node for new_record
+    bib_element = ET.fromstring(original_bib)
+    new_record_element = record_to_xml_node(new_record)
+
+    old_record_element = bib_element.find("record")
+    bib_element.remove(old_record_element)
+    bib_element.append(new_record_element)
 
     # xml_declaration=False because the Update Bib API doesn't require it, and the API
     # call fails if xml_declaration=True due to escape characters in ET's declaration


### PR DESCRIPTION
Relates to [SYS-1074](https://jira.library.ucla.edu/browse/SYS-1074)

This PR implements two new functions useful in converting between MARCXML usable by pymarc and Alma Bib XML objects. `get_MARCXML_from_bib` retrieves the record MARCXML from an Alma Bib, `and update_alma_bib_xml` inserts a MARCXML record (presumably updated by pymarc) into an existing Alma Bib record.

There is no function converting directly from MARCXML to an Alma Bib, as the Bibs contain extra metadata that cannot be extrapolated from the MARC record. There is also no function converting a \<collection> object as written by pymarc to a \<record> object, as this is more easily accomplished with pymarc. Assuming `bib_record` is a pymarc Record, the below will give the desired \<record> XML:

```
single_record = ET.tostring(
    pymarc.marcxml.record_to_xml_node(bib_record),
    encoding="utf8",
    method="xml",
    xml_declaration=False,
)