### PR TITLE
SYS-1112: Shell and python scripts to get Alma/PAC invoice error files

### DIFF
--- a/get_alma_invoice_errors.py
+++ b/get_alma_invoice_errors.py
@@ -1,0 +1,24 @@
+#!/usr/bin/env python3
+from sftp_credentials import PAC
+import pysftp
+
+
+def get_pac_error_file():
+    remote_file = "BATCH-AP-LIBRY-ERR"
+    local_file = "/tmp/" + remote_file
+    with pysftp.Connection(
+        PAC["server"], username=PAC["user"], password=PAC["password"]
+    ) as sftp:
+        print("Connected")
+        sftp.get(remote_file, local_file)
+        # Get full directory listing
+        for line in sftp.listdir_attr():
+            print(line)
+
+
+def main() -> None:
+    get_pac_error_file()
+
+
+if __name__ == "__main__":
+    main()

--- a/get_alma_invoice_errors.sh
+++ b/get_alma_invoice_errors.sh
@@ -1,0 +1,21 @@
+#!/bin/sh
+# Retrieve PAC invoice error file from campus SFTP server,
+# show contents (if any), and email message to users.
+
+# Our RHEL server has ancient default python; use modern-ish one.
+source /etc/profile.d/enablerh-python38.sh
+
+# Get file from SFTP server using python, since native sftp
+# client has no(?) support for password auth via command line.
+/home/exlsupport/alma-scripts/get_alma_invoice_errors.py
+
+echo "======================================================"
+
+DATE=`date "+%Y%m%d"` #YYYYMMDD
+FILE=/tmp/BATCH-AP-LIBRY-ERR
+if [ -s ${FILE} ]; then
+  echo "PAC INVOICE ERRORS ${DATE}:"
+  cat ${FILE}
+else
+  echo "No PAC invoice errors ${DATE}"
+fi


### PR DESCRIPTION
This PR adds:
* `get_alma_invoice_errors.py`: Python script to retrieve daily invoice error file from UCLA PAC SFTP server
* `get_alma_invoice_errors.sh`: Shell script which runs the Python script, shows contents, and is more suitable for cron usage
