### PR TITLE
ALMA-128: Add holdings display note for CAAS

### DIFF
--- a/add_CAAS_holdings_note.py
+++ b/add_CAAS_holdings_note.py
@@ -25,7 +25,8 @@ def main():
     if args.environment == "sandbox":
         # test data for sandbox environment
         report_data = [
-            {"MMS Id": "9924282823606533", "Holding Id": "22534807520006533"}
+            {"MMS Id": "9960876273606533", "Holding Id": "22316143290006533"},
+            {"MMS Id": "FAKEMMS", "Holding Id": "FAKEHOLDING"},
         ]
         alma_api_key = API_KEYS["SANDBOX"]
 
@@ -45,7 +46,7 @@ def main():
 
         alma_holding = client.get_holding(mms_id, holding_id).get("content")
         # make sure we got a valid bib
-        if b"is not valid" in alma_holding:
+        if b"is not valid" in alma_holding or b"INTERNAL_SERVER_ERROR" in alma_holding:
             print(
                 f"Error finding MMS ID {mms_id}, Holding ID {holding_id}. Skipping this record."
             )
@@ -54,7 +55,7 @@ def main():
             # convert to Pymarc to handle fields and subfields
             pymarc_record = get_pymarc_record_from_bib(alma_holding)
             pymarc_852 = pymarc_record.get_fields("852")[0]
-            pymarc_852.add_subfield(code="z", value="Reading Room Use ONLY.")
+            pymarc_852.add_subfield(code="z", value="Reading Room Use ONLY.", pos=0)
             # convert back to Alma Holding and send update
             new_alma_holding = prepare_bib_for_update(alma_holding, pymarc_record)
             client.update_holding(mms_id, holding_id, new_alma_holding)

--- a/add_CAAS_holdings_note.py
+++ b/add_CAAS_holdings_note.py
@@ -1,0 +1,61 @@
+import argparse
+from alma_api_keys import API_KEYS
+from alma_api_client import AlmaAPIClient
+from alma_analytics_client import AlmaAnalyticsClient
+from alma_marc import get_pymarc_record_from_bib, prepare_bib_for_update
+
+
+def get_holdings_report(analytics_api_key: str) -> list:
+    # analytics only available in prod environment
+    aac = AlmaAnalyticsClient(analytics_api_key)
+    report_path = (
+        "/shared/University of California Los Angeles (UCLA) 01UCS_LAL"
+        "/Collections/Reports/CAAS Holdings for Display Note"
+    )
+    aac.set_report_path(report_path)
+    report = aac.get_report()
+    return report
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("environment", help="Alma environment (sandbox or production)")
+    args = parser.parse_args()
+
+    if args.environment == "sandbox":
+        # test data for sandbox environment
+        report_data = [
+            {"MMS Id": "9924282823606533", "Holding Id": "22534807520006533"}
+        ]
+        alma_api_key = API_KEYS["SANDBOX"]
+
+    elif args.environment == "production":
+        analytics_api_key = API_KEYS["DIIT_ANALYTICS"]
+        alma_api_key = API_KEYS["DIIT_SCRIPTS"]
+        report_data = get_holdings_report(analytics_api_key)
+
+    client = AlmaAPIClient(alma_api_key)
+
+    for item in report_data:
+        mms_id = item["MMS Id"]
+        holding_id = item["Holding Id"]
+
+        alma_holding = client.get_holding(mms_id, holding_id).get("content")
+        # make sure we got a valid bib
+        if b"is not valid" in alma_holding:
+            print(
+                f"Error finding MMS ID {mms_id}, Holding ID {holding_id}. Skipping this record."
+            )
+            continue
+
+        # convert to Pymarc to handle fields and subfields
+        pymarc_record = get_pymarc_record_from_bib(alma_holding)
+        pymarc_852 = pymarc_record.get_fields("852")[0]
+        pymarc_852.add_subfield(code="z", value="Reading Room Use ONLY.")
+        # convert back to Alma Holding and send update
+        new_alma_holding = prepare_bib_for_update(alma_holding, pymarc_record)
+        client.update_holding(mms_id, holding_id, new_alma_holding)
+
+
+if __name__ == "__main__":
+    main()

--- a/add_CAAS_holdings_note.py
+++ b/add_CAAS_holdings_note.py
@@ -62,11 +62,7 @@ def main():
             pymarc_852.add_subfield(code="z", value="Reading Room Use ONLY.", pos=zpos)
             # convert back to Alma Holding and send update
             new_alma_holding = prepare_bib_for_update(alma_holding, pymarc_record)
-            # These 3 lines added for QAD testing
-            import pprint
-
-            pprint.pprint(new_alma_holding.decode().replace("><", ">\n<"), width=160)
-            # client.update_holding(mms_id, holding_id, new_alma_holding)
+            client.update_holding(mms_id, holding_id, new_alma_holding)
             updated_holdings_count += 1
     print(f"Finished updating {updated_holdings_count} holdings.")
     print(f"Encountered {errored_holdings_count} errors.")

--- a/add_CAAS_holdings_note.py
+++ b/add_CAAS_holdings_note.py
@@ -60,6 +60,7 @@ def main():
             client.update_holding(mms_id, holding_id, new_alma_holding)
             updated_holdings_count += 1
     print(f"Finished updating {updated_holdings_count} holdings.")
+    print(f"Encountered {errored_holdings_count} errors.")
 
 
 if __name__ == "__main__":

--- a/alma_api_client.py
+++ b/alma_api_client.py
@@ -211,6 +211,25 @@ class AlmaAPIClient:
         api = f"/almaws/v1/bibs/{mms_id}"
         return self._call_put_api(api, data, parameters, format="xml")
 
+    def get_holding(
+        self, mms_id: str, holding_id: str, parameters: dict = None
+    ) -> dict:
+        """Return dictionary response, with Alma holding record (in Alma XML format),
+        in "content" element.
+        """
+        if parameters is None:
+            parameters = {}
+        api = f"/almaws/v1/bibs/{mms_id}/holdings/{holding_id}"
+        return self._call_get_api(api, parameters, format="xml")
+
+    def update_holding(
+        self, mms_id: str, holding_id: str, data: str, parameters: dict = None
+    ) -> dict:
+        if parameters is None:
+            parameters = {}
+        api = f"/almaws/v1/bibs/{mms_id}/holdings/{holding_id}"
+        return self._call_put_api(api, data, format="xml")
+
     def get_set_members(self, set_id: str, parameters: dict = None) -> None:
         if parameters is None:
             parameters = {}


### PR DESCRIPTION
Implements [ALMA-128](https://jira.library.ucla.edu/browse/ALMA-128)

Adds two new functions to the Alma API client to support holdings records GET and PUT, and uses these in a script to add an 852 $z note on CAAS holdings.

The Analytics Report data is limited to the relevant library's holdings (confirmed via another report to never contain 852 $z), so the script simply inserts this subfield on all records. Tested in Sandbox on one holdings record, not yet tested with report integration in Production. 
