### PR TITLE
SYS-1552: Add one-time bookplate update script, and remove report length check in add_bib_ebookplates.py

### DIFF
--- a/add_bib_ebookplates.py
+++ b/add_bib_ebookplates.py
@@ -214,7 +214,7 @@ def main():
         total_bibs_processed = (
             total_bibs_updated + total_bibs_skipped + total_bibs_errored
         )
-        if total_bibs_processed % (len(report_with_ebookplates) / 20) == 0:
+        if total_bibs_processed % (len(report_with_ebookplates) // 20) == 0:
             logging.info(f"Processed {total_bibs_processed} bibs.")
 
     print()

--- a/add_bib_ebookplates.py
+++ b/add_bib_ebookplates.py
@@ -55,12 +55,6 @@ def get_report_ebookplates(report: list, input_file: str) -> list:
                 current_item["spac_url"] = line["URL"]
                 new_report.append(current_item)
 
-    # sanity check - same number of items before and after SPAC mapping?
-    if len(report) != len(new_report):
-        quit(
-            """Mapping length mismatch. The mapping file may contain duplicate fund
-            codes, or may be missing fund codes. Please check inputs."""
-        )
     return new_report
 
 

--- a/tests/data/sample_SPAC_mappings.csv
+++ b/tests/data/sample_SPAC_mappings.csv
@@ -1,5 +1,7 @@
 SPAC,NAME,LIBRARY,FUND,URL,Note
 SPAC1,Bookplate Label #1,YRL SpecColl,FUND1,https://example.com,This column may contain notes
 SPAC2,Bookplate Label #2,Biomed HistDiv,"FUND2A, FUND2B",https://another-example.com, 
-SPAC3,Bookplate Label #3,"",FUND3,"", 
-SPAC4,Bookplate Label #4,IMCS, ,"",
+SPAC3,Bookplate Label #3,,FUND3,, 
+SPAC4,Bookplate Label #4,IMCS,FUND4,https://example.com,
+SPAC5,Bookplate Label #5,,FUND4,https://another-example.com,
+SPAC6,Bookplate Label #6,,,,

--- a/tests/test_add_bib_ebookplates.py
+++ b/tests/test_add_bib_ebookplates.py
@@ -65,7 +65,7 @@ class TestAddBibEbookplates(unittest.TestCase):
         report_with_ebookplates = get_report_ebookplates(
             sample_report_data, sample_mapping_file
         )
-        # in mapping file, FUND3 maps to SPAC4 and SPAC5
+        # in mapping file, FUND4 maps to SPAC4 and SPAC5
         self.assertEqual(report_with_ebookplates[0]["spac_code"], "SPAC4")
         self.assertEqual(report_with_ebookplates[0]["spac_name"], "Bookplate Label #4")
         self.assertEqual(report_with_ebookplates[0]["spac_url"], "https://example.com")

--- a/tests/test_add_bib_ebookplates.py
+++ b/tests/test_add_bib_ebookplates.py
@@ -57,6 +57,25 @@ class TestAddBibEbookplates(unittest.TestCase):
             report_with_ebookplates[1]["spac_url"], "https://another-example.com"
         )
 
+    def test_get_report_ebookplates_multiple_spacs_single_fund(self):
+        sample_mapping_file = "tests/data/sample_SPAC_mappings.csv"
+        sample_report_data = [
+            {"MMS Id": "MMS1", "Fund Code": "FUND4"},
+        ]
+        report_with_ebookplates = get_report_ebookplates(
+            sample_report_data, sample_mapping_file
+        )
+        # in mapping file, FUND3 maps to SPAC4 and SPAC5
+        self.assertEqual(report_with_ebookplates[0]["spac_code"], "SPAC4")
+        self.assertEqual(report_with_ebookplates[0]["spac_name"], "Bookplate Label #4")
+        self.assertEqual(report_with_ebookplates[0]["spac_url"], "https://example.com")
+        self.assertEqual(report_with_ebookplates[1]["spac_code"], "SPAC5")
+        self.assertEqual(report_with_ebookplates[1]["spac_name"], "Bookplate Label #5")
+        self.assertEqual(
+            report_with_ebookplates[1]["spac_url"],
+            "https://another-example.com",
+        )
+
     def test_is_new_966_original_empty(self):
         record = Record()
         spac_code = "SPAC"

--- a/tests/test_update_bookplates_one_time.py
+++ b/tests/test_update_bookplates_one_time.py
@@ -1,0 +1,135 @@
+import unittest
+from pymarc import Field, Subfield
+from update_bookplates_one_time import (
+    get_spac_mappings,
+    needs_bookplate_update,
+    get_spac_info,
+    update_existing_966,
+)
+
+
+class TestUpdateBookplatesOneTime(unittest.TestCase):
+    def test_needs_bookplate_update(self):
+        spac_mappings = [
+            {"SPAC": "SPAC1", "NAME": "SPAC Name", "URL": "https://example.com"},
+            {"SPAC": "SPAC2", "NAME": "SPAC Name2", "URL": "https://example2.com"},
+        ]
+        old_field = Field(
+            tag="966",
+            indicators=[" ", " "],
+            subfields=[
+                Subfield(code="a", value="SPAC1"),
+                Subfield(code="b", value="Wrong SPAC Name"),
+                Subfield(code="c", value="https://example.com"),
+            ],
+        )
+        # any matching SPAC code should trigger an update
+        self.assertTrue(needs_bookplate_update(old_field, spac_mappings))
+
+    def test_needs_bookplate_update_no_match(self):
+        spac_mappings = [
+            {"SPAC": "SPAC1", "NAME": "SPAC Name", "URL": "https://example.com"},
+            {"SPAC": "SPAC2", "NAME": "SPAC Name2", "URL": "https://example2.com"},
+        ]
+        old_field = Field(
+            tag="966",
+            indicators=[" ", " "],
+            subfields=[
+                Subfield(code="a", value="SPAC3"),
+                Subfield(code="b", value="SPAC Name"),
+                Subfield(code="c", value="https://example.com"),
+            ],
+        )
+        # no matching SPAC code should not trigger an update
+        self.assertFalse(needs_bookplate_update(old_field, spac_mappings))
+
+    def test_get_spac_info(self):
+        spac_mappings = [
+            {"SPAC": "SPAC1", "NAME": "SPAC Name", "URL": "https://example.com"},
+            {"SPAC": "SPAC2", "NAME": "SPAC Name2", "URL": "https://example2.com"},
+        ]
+        field_966 = Field(
+            tag="966",
+            indicators=[" ", " "],
+            subfields=[
+                Subfield(code="a", value="SPAC1"),
+                Subfield(code="b", value="SPAC Name"),
+                Subfield(code="c", value="https://example.com"),
+            ],
+        )
+        self.assertEqual(
+            get_spac_info(spac_mappings, field_966),
+            {"spac_name": "SPAC Name", "spac_url": "https://example.com"},
+        )
+
+    def test_get_spac_info_different_values(self):
+        spac_mappings = [
+            {"SPAC": "SPAC1", "NAME": "SPAC Name", "URL": "https://example.com"},
+            {"SPAC": "SPAC2", "NAME": "SPAC Name2", "URL": "https://example2.com"},
+        ]
+        field_966 = Field(
+            tag="966",
+            indicators=[" ", " "],
+            subfields=[
+                Subfield(code="a", value="SPAC1"),
+                Subfield(code="b", value="Different Name"),
+                Subfield(code="c", value="https://different-example.com"),
+            ],
+        )
+        self.assertEqual(
+            get_spac_info(spac_mappings, field_966),
+            {"spac_name": "SPAC Name", "spac_url": "https://example.com"},
+        )
+
+    def test_update_existing_966_add_URL(self):
+        old_field = Field(
+            tag="966",
+            indicators=[" ", " "],
+            subfields=[
+                Subfield(code="a", value="SPAC"),
+                Subfield(code="b", value="SPAC Name"),
+                Subfield(code="c", value=""),
+            ],
+        )
+        spac_url = "https://example.com"
+        spac_name = "SPAC Name"
+        update_existing_966(old_field, spac_name, spac_url)
+        self.assertEqual(old_field.get_subfields("c")[0], spac_url)
+        self.assertEqual(old_field.get_subfields("b")[0], spac_name)
+
+    def test_update_existing_966_remove_URL(self):
+        old_field = Field(
+            tag="966",
+            indicators=[" ", " "],
+            subfields=[
+                Subfield(code="a", value="SPAC"),
+                Subfield(code="b", value="SPAC Name"),
+                Subfield(code="c", value="https://example.com"),
+            ],
+        )
+        spac_url = ""
+        spac_name = "SPAC Name"
+        update_existing_966(old_field, spac_name, spac_url)
+        self.assertEqual(old_field.get_subfields("c"), [])
+        self.assertEqual(old_field.get_subfields("b")[0], spac_name)
+
+    def test_get_spac_mappings(self):
+        spac_mappings = get_spac_mappings("tests/data/sample_SPAC_mappings.csv")
+        # only two rows in the test file have a valid URL
+        sample_mappings = [
+            {
+                "SPAC": "SPAC1",
+                "NAME": "Bookplate Label #1",
+                "URL": "https://example.com",
+            },
+            {
+                "SPAC": "SPAC2",
+                "NAME": "Bookplate Label #2",
+                "URL": "https://another-example.com",
+            },
+        ]
+        self.assertEqual(spac_mappings, sample_mappings)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_update_bookplates_one_time.py
+++ b/tests/test_update_bookplates_one_time.py
@@ -115,7 +115,7 @@ class TestUpdateBookplatesOneTime(unittest.TestCase):
 
     def test_get_spac_mappings(self):
         spac_mappings = get_spac_mappings("tests/data/sample_SPAC_mappings.csv")
-        # only two rows in the test file have a valid URL
+        # only four rows in the test file have a valid URL
         sample_mappings = [
             {
                 "SPAC": "SPAC1",
@@ -125,6 +125,16 @@ class TestUpdateBookplatesOneTime(unittest.TestCase):
             {
                 "SPAC": "SPAC2",
                 "NAME": "Bookplate Label #2",
+                "URL": "https://another-example.com",
+            },
+            {
+                "SPAC": "SPAC4",
+                "NAME": "Bookplate Label #4",
+                "URL": "https://example.com",
+            },
+            {
+                "SPAC": "SPAC5",
+                "NAME": "Bookplate Label #5",
                 "URL": "https://another-example.com",
             },
         ]

--- a/update_bookplates_one_time.py
+++ b/update_bookplates_one_time.py
@@ -126,7 +126,7 @@ def main():
     report_index = 0
 
     for item in report:
-        report_index += 1
+
         mms_id = item["MMS Id"]
         bib_was_updated = False
 
@@ -174,6 +174,8 @@ def main():
         # every 5% of records, log progress
         if report_index % (len(report) / 20) == 0:
             logging.info(f"Processed {report_index} bibs.")
+
+        report_index += 1
 
     print()
     print(

--- a/update_bookplates_one_time.py
+++ b/update_bookplates_one_time.py
@@ -1,0 +1,188 @@
+import csv
+import argparse
+import logging
+from alma_api_keys import API_KEYS
+from alma_api_client import AlmaAPIClient
+from alma_analytics_client import AlmaAnalyticsClient
+from alma_marc import get_pymarc_record_from_bib, prepare_bib_for_update
+from pymarc import Field
+
+logging.basicConfig(filename="update_bookplates_one_time.log", level=logging.DEBUG)
+
+
+def get_mms_report(analytics_api_key: str) -> list:
+    """Get the report of MMS IDs and current 966 contents from Alma Analytics."""
+    # analytics only available in prod environment
+    aac = AlmaAnalyticsClient(analytics_api_key)
+    report_path = (
+        "/shared/University of California Los Angeles (UCLA) 01UCS_LAL"
+        "/Cataloging/Reports/API/MMS IDs for 966 updates"
+    )
+    aac.set_report_path(report_path)
+    report = aac.get_report()
+    return report
+
+
+def get_spac_mappings(input_file: str) -> list:
+    """Get SPAC mappings from a CSV file. Filter out any lines without a valid URL."""
+    spac_mappings = []
+    with open(input_file, newline="", encoding="utf-8-sig") as csv_file:
+        reader = csv.DictReader(csv_file)
+        for line in reader:
+            # remove leading/trailing whitespace from all values
+            line = {k: v.strip() for k, v in line.items()}
+            # first, check if the line has a valid URL. If not, skip it.
+            if not line["URL"]:
+                continue
+            elif line["URL"][:4] != "http":
+                continue
+            else:
+                current_line = {
+                    "SPAC": line["SPAC"],
+                    "NAME": line["NAME"],
+                    "URL": line["URL"],
+                }
+                spac_mappings.append(current_line)
+    return spac_mappings
+
+
+def needs_bookplate_update(old_field: Field, spac_mappings: list) -> bool:
+    """Check if a 966 field matches a SPAC code. If so, assume it needs updating."""
+    # check if the SPAC code in the 966 field is in the list of SPAC mappings
+    for spac_mapping in spac_mappings:
+        if spac_mapping["SPAC"] == old_field.get_subfields("a")[0]:
+            return True
+    return False
+
+
+def get_spac_info(spac_mappings: list, field_966: Field) -> dict:
+    """Get the SPAC name and URL from the mappings to update a 966."""
+    for spac_mapping in spac_mappings:
+        if spac_mapping["SPAC"] == field_966.get_subfields("a")[0]:
+            return {"spac_name": spac_mapping["NAME"], "spac_url": spac_mapping["URL"]}
+    return {"spac_name": "", "spac_url": ""}
+
+
+def update_existing_966(field_966: Field, spac_name: str, spac_url: str) -> None:
+    """Update the URL and bookplate text in an existing 966 field."""
+    # update $b for bookplate text
+    field_966.delete_subfield("b")
+    field_966.add_subfield("b", spac_name)
+    # update $c for URL
+    field_966.delete_subfield("c")
+    # if spac_url is an empty string, don't add $c back in
+    if spac_url:
+        field_966.add_subfield("c", spac_url)
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "spac_mappings_file", help="Path to the SPAC mappings .csv file"
+    )
+    parser.add_argument(
+        "environment",
+        help="Alma environment (sandbox or production), or 'debug' for a small test set.",
+    )
+    parser.add_argument(
+        "--start-index", type=int, help="Start processing report data at this index"
+    )
+    args = parser.parse_args()
+
+    if args.environment == "debug":
+        # test data for sandbox environment
+        report = [
+            {"MMS Id": "9911656853606533"},
+            {"MMS Id": "9990572683606533"},
+        ]
+        alma_api_key = API_KEYS["SANDBOX"]
+
+    elif args.environment == "sandbox":
+        # use production analytics key for sandbox environment, since sandbox doesn't have analytics
+        analytics_api_key = API_KEYS["DIIT_ANALYTICS"]
+        alma_api_key = API_KEYS["SANDBOX"]
+        report = get_mms_report(analytics_api_key)
+
+    elif args.environment == "production":
+        analytics_api_key = API_KEYS["DIIT_ANALYTICS"]
+        alma_api_key = API_KEYS["DIIT_SCRIPTS"]
+        report = get_mms_report(analytics_api_key)
+
+    # if a start index is provided, slice the report to start at that index
+    if args.start_index:
+        report = report[args.start_index :]
+
+    print(f"Beginning processing {len(report)} bib e-bookplates")
+    print()
+
+    client = AlmaAPIClient(alma_api_key)
+
+    spac_mappings = get_spac_mappings(args.spac_mappings_file)
+
+    # initialize counters
+    total_bibs_updated = 0
+    total_bibs_skipped = 0
+    total_bibs_errored = 0
+    report_index = 0
+
+    for item in report:
+        report_index += 1
+        mms_id = item["MMS Id"]
+        bib_was_updated = False
+
+        # get bib from Alma
+        alma_bib = client.get_bib(mms_id).get("content")
+        # check for error in bib response, usually due to invalid MMS ID
+        if b"errorsExist" in alma_bib:
+            logging.info(
+                f"Got an error finding bib record for MMS ID {mms_id}. Skipping this record."
+            )
+            total_bibs_errored += 1
+            continue
+        # if we get a bad response, halt the script
+        # report is sorted by MMS ID, so we can use this to resume later if needed
+        if not alma_bib:
+            logging.error(
+                f"Unexpected response for MMS ID {mms_id}, index {report_index}. Exiting."
+            )
+            exit()
+
+        # convert to Pymarc to handle fields and subfields
+        pymarc_record = get_pymarc_record_from_bib(alma_bib)
+        for field_966 in pymarc_record.get_fields("966"):
+            if needs_bookplate_update(field_966, spac_mappings):
+                # get the SPAC name and URL from the mappings
+                spac_info = get_spac_info(spac_mappings, field_966)
+                spac_name = spac_info["spac_name"]
+                spac_url = spac_info["spac_url"]
+                update_existing_966(field_966, spac_name, spac_url)
+                logging.debug(
+                    f"Updated bookplate. MMS ID: {mms_id}, SPAC Name: {spac_name}",
+                )
+                bib_was_updated = True
+
+        if bib_was_updated:
+            new_alma_bib = prepare_bib_for_update(alma_bib, pymarc_record)
+            client.update_bib(mms_id, new_alma_bib)
+            total_bibs_updated += 1
+        else:
+            # this case shouldn't happen, since report is limited to records that need updating
+            # log it in case it does
+            total_bibs_skipped += 1
+            logging.info(f"Skipping MMS ID {mms_id}. No 966 updates needed.")
+
+        # every 5% of records, log progress
+        if report_index % (len(report) / 20) == 0:
+            logging.info(f"Processed {report_index} bibs.")
+
+    print()
+    print(
+        "Finished adding ebookplates. ",
+        f"{total_bibs_updated} bibs updated. ",
+        f"{total_bibs_skipped} bibs skipped with no 966 updates needed. ",
+        f"{total_bibs_errored} bibs skipped due to errors.",
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/update_bookplates_one_time.py
+++ b/update_bookplates_one_time.py
@@ -172,7 +172,7 @@ def main():
             logging.info(f"Skipping MMS ID {mms_id}. No 966 updates needed.")
 
         # every 5% of records, log progress
-        if report_index % (len(report) / 20) == 0:
+        if report_index % (len(report) // 20) == 0:
             logging.info(f"Processed {report_index} bibs.")
 
         report_index += 1


### PR DESCRIPTION
Implements [SYS-1552](https://uclalibrary.atlassian.net/browse/SYS-1552)

This PR has two parts:

1. A small change to `add_bib_ebookplates.py` to remove a check that mapping SPAC codes did not change the length of the report. In real data, multiple fund codes can map to the same SPAC (and SPACs can map to multiple fund codes). In this case, any record associated with one of these fund codes should get all relevant bookplates applied. A new test is added for this (`test_get_report_ebookplates_multiple_spacs_single_fund`), and the test mapping file is updated to support it.
2. A new script, `update_bookplates_one_time.py`. This is intended for one-time use to update all existing bibs with 966 fields that need SPAC Name or URL changes. This is done with a new Alma Analytics report available at `/Cataloging/Reports/API/MMS IDs for 966 updates`. This report finds only those records with a 966 field containing a SPAC that should be updated, and presents them in order of increasing MMS ID. Because this logic is done in the report, the script can be simpler in its logic than `add_bib_ebookplates.py` - e.g. there is no case where new 966 fields are added.
This script takes three arguments:
* SPAC Mappings file. This should be a .csv file in the same format as that needed for `add_bib_ebookplates.py`. The sample file in the test directory should work here.
* Environment. Again like `add_bib_ebookplates.py`, either "sandbox", "production", or "debug".
* `--start-index`. Optional integer value to start at this index in the report (starting at 0, as usual in Python). This is intended to be potentially useful if the script run is interrupted. Lines 144-148 of the script are my attempt at dealing with a "disappearing" API by logging the current index and exiting.

Tests for `update_bookplates_one_time.py` are included, and can be run separately (`python -m unittest tests/test_update_bookplates_one_time.py`) or together with the `add_bib_ebookplates` tests (`python -m unittest discover -s tests`).


[SYS-1552]: https://uclalibrary.atlassian.net/browse/SYS-1552?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ