### PR TITLE
SYS-1554: fix logging in bookplate update scripts

### DIFF
--- a/add_bib_ebookplates.py
+++ b/add_bib_ebookplates.py
@@ -228,10 +228,12 @@ def main():
         total_bibs_processed = (
             total_bibs_updated + total_bibs_skipped + total_bibs_errored
         )
-        # Take 1%, round down, add 1 to avoid 0 when length < 20
+        # Take 1%, round down, add 1 to avoid 0 when length < 100
         progress_interval = (len(report_with_ebookplates) // 100) + 1
         if total_bibs_processed % progress_interval == 0:
-            logging.info(f"Processed {total_bibs_processed} bibs.")
+            logging.info(
+                f"Processed {total_bibs_processed} bibs. Last MMS ID: {mms_id}"
+            )
 
     logging.info("Finished adding ebookplates.")
     logging.info(f"{total_bibs_updated} bibs updated.")

--- a/update_bookplates_one_time.py
+++ b/update_bookplates_one_time.py
@@ -178,13 +178,12 @@ def main():
             total_bibs_skipped += 1
             logging.info(f"Skipping MMS ID {mms_id}. No 966 updates needed.")
 
+        report_index += 1
         # every 1% of records, log progress
-        # Take 1%, round down, add 1 to avoid 0 when length < 20
+        # Take 1%, round down, add 1 to avoid 0 when length < 100
         progress_interval = (len(report) // 100) + 1
         if report_index % progress_interval == 0:
-            logging.info(f"Processed {report_index} bibs.")
-
-        report_index += 1
+            logging.info(f"Processed {report_index} bibs. Last MMS ID: {mms_id}")
 
     logging.info("Finished adding ebookplates.")
     logging.info(f"{total_bibs_updated} bibs updated.")


### PR DESCRIPTION
Implements [SYS-1554](https://uclalibrary.atlassian.net/browse/SYS-1554)

Several logging-related changes to `add_bib_ebookplates.py` and `update_bookplates_one_time.py`:
* Log level is now set with the command line argument `--log-level`, with possible values `"DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"`. `INFO` is default.
* Logs from `urllib3` with lower priority than `WARNING` are now suppressed.
* All print statements have been changed to logs at the `INFO` level.
* Report index is now logged every 1% of records for easier rerunning in production.
* The optional `--start-index` argument is now supported in `add_bib_ebookplates.py`.

[SYS-1554]: https://uclalibrary.atlassian.net/browse/SYS-1554?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ