### PR TITLE
SYS-1567: Delete bookplates from holdings

### DIFF
--- a/remove_bookplates_one_time.py
+++ b/remove_bookplates_one_time.py
@@ -1,0 +1,233 @@
+import argparse
+import logging
+from alma_api_keys import API_KEYS
+from alma_api_client import AlmaAPIClient
+from alma_analytics_client import AlmaAnalyticsClient
+from alma_marc import get_pymarc_record_from_bib, prepare_bib_for_update
+from pymarc import Field
+
+
+def get_856_report(analytics_api_key: str) -> list:
+    # analytics only available in prod environment
+    aac = AlmaAnalyticsClient(analytics_api_key)
+    report_path = (
+        "/shared/University of California Los Angeles (UCLA) 01UCS_LAL"
+        "/Cataloging/Reports/API/856 Bookplates to Remove"
+    )
+    aac.set_report_path(report_path)
+    report = aac.get_report()
+    return report
+
+
+def get_966_report(analytics_api_key: str) -> list:
+    # analytics only available in prod environment
+    aac = AlmaAnalyticsClient(analytics_api_key)
+    report_path = (
+        "/shared/University of California Los Angeles (UCLA) 01UCS_LAL"
+        "/Cataloging/Reports/API/966 Bookplates to Remove"
+    )
+    aac.set_report_path(report_path)
+    report = aac.get_report()
+    return report
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("environment", help="Alma environment (sandbox or production)")
+    parser.add_argument(
+        "--log-level",
+        choices=["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"],
+        default="INFO",
+        help="Set the logging level",
+    )
+    args = parser.parse_args()
+
+    logging.basicConfig(filename="remove_bookplates_one_time.log", level=args.log_level)
+    # always suppress urllib3 logs with lower level than WARNING
+    logging.getLogger("urllib3").setLevel(logging.WARNING)
+
+    if args.environment == "sandbox":
+        alma_api_key = API_KEYS["SANDBOX"]
+        # analytics only available in prod environment
+        analytics_api_key = API_KEYS["DIIT_ANALYTICS"]
+
+    elif args.environment == "production":
+        analytics_api_key = API_KEYS["DIIT_ANALYTICS"]
+        alma_api_key = API_KEYS["DIIT_SCRIPTS"]
+
+    logging.info("Getting 966 report data")
+    report_data_966 = get_966_report(analytics_api_key)
+    logging.info("Getting 856 report data")
+    report_data_856 = get_856_report(analytics_api_key)
+
+    # limit to first 100 records in each report for testing
+    if args.environment == "sandbox":
+        report_data_966 = report_data_966[:100]
+        report_data_856 = report_data_856[:100]
+
+    client = AlmaAPIClient(alma_api_key)
+
+    bookplates_to_leave_966 = [
+        "AFC",
+        "AFI",
+        "AHA",
+        "AMA",
+        "AM",
+        "BBA",
+        "CFS",
+        "CSC",
+        "DEN",
+        "DGA",
+        "DLX",
+        "ERO",
+        "FNF",
+        "GKC",
+        "HEA",
+        "HHF",
+        "HLC",
+        "HRC",
+        "ICC",
+        "IWF",
+        "JCC",
+        "JUN",
+        "LAI",
+        "LAR",
+        "MCC",
+        "MIC",
+        "MPC",
+        "MTC",
+        "OUT",
+        "PHI",
+        "PPB",
+        "PPI",
+        "RAS",
+        "SOD",
+        "STC",
+        "SUN",
+        "UTV",
+        "WBA",
+        "WEL",
+        "WIF",
+    ]
+
+    logging.info(f"Processing {len(report_data_966)} 966 bookplates")
+    errored_holdings_count = 0
+    updated_holdings_count = 0
+    skipped_holdings_count = 0
+
+    for index, item in enumerate(report_data_966):
+        mms_id = item["MMS Id"]
+        holding_id = item["Holding Id"]
+
+        alma_holding = client.get_holding(mms_id, holding_id).get("content")
+        # make sure we got a valid bib
+        if (
+            b"is not valid" in alma_holding
+            or b"INTERNAL_SERVER_ERROR" in alma_holding
+            or b"Search failed" in alma_holding
+            or alma_holding is None
+        ):
+            logging.error(
+                f"Error finding MMS ID {mms_id}, Holding ID {holding_id}. Skipping this record."
+            )
+            errored_holdings_count += 1
+
+        else:
+            # convert to Pymarc to handle fields and subfields
+            pymarc_record = get_pymarc_record_from_bib(alma_holding)
+            pymarc_966s = pymarc_record.get_fields("966")
+            if not pymarc_966s:
+                logging.info(
+                    f"No 966 found for MMS ID {mms_id}, Holding ID {holding_id}"
+                )
+                skipped_holdings_count += 1
+            else:
+                for field_966 in pymarc_966s:
+                    if needs_966_removed(field_966, bookplates_to_leave_966):
+                        pymarc_record.remove_field(field_966)
+                        logging.info(
+                            f"Removing 966 bookplate from MMS ID {mms_id}, Holding ID {holding_id}"
+                        )
+                    else:
+                        logging.info(
+                            f"Not removing 966 bookplate from MMS ID {mms_id}, ",
+                            f"Holding ID {holding_id}",
+                        )
+                # convert back to Alma Holding and send update
+                new_alma_holding = prepare_bib_for_update(alma_holding, pymarc_record)
+                client.update_holding(mms_id, holding_id, new_alma_holding)
+                updated_holdings_count += 1
+    logging.info("966 Bookplates Updated")
+    logging.info(f"Total Holdings Updated: {updated_holdings_count}")
+    logging.info(f"Total Holdings Skipped: {skipped_holdings_count}")
+    logging.info(f"Total Holdings Errored: {errored_holdings_count}")
+
+    logging.info(f"Processing {len(report_data_856)} 856 bookplates")
+    errored_holdings_count = 0
+    updated_holdings_count = 0
+    skipped_holdings_count = 0
+    for index, item in enumerate(report_data_856):
+        mms_id = item["MMS Id"]
+        holding_id = item["Holding Id"]
+
+        alma_holding = client.get_holding(mms_id, holding_id).get("content")
+        # make sure we got a valid bib
+        if (
+            b"is not valid" in alma_holding
+            or b"INTERNAL_SERVER_ERROR" in alma_holding
+            or b"Search failed" in alma_holding
+            or alma_holding is None
+        ):
+            logging.error(
+                f"Error finding MMS ID {mms_id}, Holding ID {holding_id}. Skipping this record."
+            )
+            errored_holdings_count += 1
+        else:
+            # convert to Pymarc to handle fields and subfields
+            pymarc_record = get_pymarc_record_from_bib(alma_holding)
+            pymarc_856s = pymarc_record.get_fields("856")
+            if not pymarc_856s:
+                logging.info(
+                    f"No 856 found for MMS ID {mms_id}, Holding ID {holding_id}"
+                )
+                skipped_holdings_count += 1
+            else:
+                for field_856 in pymarc_856s:
+                    if needs_856_removed(field_856):
+                        pymarc_record.remove_field(field_856)
+                        logging.info(
+                            f"Removing 856 bookplate from MMS ID {mms_id}, Holding ID {holding_id}"
+                        )
+                    else:
+                        logging.info(
+                            f"Not removing 856 bookplate from MMS ID {mms_id}, ",
+                            f"Holding ID {holding_id}",
+                        )
+                # convert back to Alma Holding and send update
+                new_alma_holding = prepare_bib_for_update(alma_holding, pymarc_record)
+                client.update_holding(mms_id, holding_id, new_alma_holding)
+                updated_holdings_count += 1
+    logging.info("856 Bookplates Updated")
+    logging.info(f"Total Holdings Updated: {updated_holdings_count}")
+    logging.info(f"Total Holdings Skipped: {skipped_holdings_count}")
+    logging.info(f"Total Holdings Errored: {errored_holdings_count}")
+    logging.info("Script Complete")
+
+
+def needs_966_removed(field_966: Field, bookplates_to_leave: list) -> bool:
+    # only remove 966s that don't contain any of the SPACs in bookplates_to_leave
+    for term in bookplates_to_leave:
+        if term in field_966.format_field():
+            return False
+    return True
+
+
+def needs_856_removed(field_856: Field) -> bool:
+    # only remove 856s that contain "Bookplate"
+    if "Bookplate" in field_856.format_field():
+        return True
+    return False
+
+
+if __name__ == "__main__":
+    main()

--- a/remove_bookplates_one_time.py
+++ b/remove_bookplates_one_time.py
@@ -1,9 +1,12 @@
 import argparse
 import logging
 from alma_api_keys import API_KEYS
-from alma_api_client import AlmaAPIClient
+from alma_api_client import (
+    AlmaAPIClient,
+    get_pymarc_record_from_bib,
+    prepare_bib_for_update,
+)
 from alma_analytics_client import AlmaAnalyticsClient
-from alma_marc import get_pymarc_record_from_bib, prepare_bib_for_update
 from pymarc import Field
 
 
@@ -59,11 +62,6 @@ def main():
     report_data_966 = get_966_report(analytics_api_key)
     logging.info("Getting 856 report data")
     report_data_856 = get_856_report(analytics_api_key)
-
-    # limit to first 100 records in each report for testing
-    if args.environment == "sandbox":
-        report_data_966 = report_data_966[:100]
-        report_data_856 = report_data_856[:100]
 
     client = AlmaAPIClient(alma_api_key)
 

--- a/remove_bookplates_one_time.py
+++ b/remove_bookplates_one_time.py
@@ -8,6 +8,7 @@ from alma_api_client import (
 )
 from alma_analytics_client import AlmaAnalyticsClient
 from pymarc import Field
+from typing import Optional
 
 
 def get_856_report(analytics_api_key: str) -> list:
@@ -43,6 +44,24 @@ def main():
         default="INFO",
         help="Set the logging level",
     )
+    parser.add_argument(
+        "--start-index-966-report",
+        type=int,
+        default=0,
+        help="Start index for 966 report",
+    )
+    parser.add_argument(
+        "--start-index-856-report",
+        type=int,
+        default=0,
+        help="Start index for 856 report",
+    )
+    parser.add_argument(
+        "--limit",
+        type=int,
+        default=None,
+        help="Limit the number of records to process",
+    )
     args = parser.parse_args()
 
     logging.basicConfig(filename="remove_bookplates_one_time.log", level=args.log_level)
@@ -63,14 +82,27 @@ def main():
     logging.info("Getting 856 report data")
     report_data_856 = get_856_report(analytics_api_key)
 
+    # start at index specified in args
+    report_data_966 = report_data_966[args.start_index_966_report :]
+    report_data_856 = report_data_856[args.start_index_856_report :]
+
+    # if a limit is specified, only process that many records
+    if args.limit:
+        report_data_966 = report_data_966[: args.limit]
+        report_data_856 = report_data_856[: args.limit]
+
     client = AlmaAPIClient(alma_api_key)
 
+    # bookplates to leave in 966 field (FTVA SPACs)
     bookplates_to_leave_966 = [
         "AFC",
         "AFI",
         "AHA",
-        "AMA",
         "AM",
+        "AMA",
+        "AMAS",
+        "AMI",
+        "AMP",
         "BBA",
         "CFS",
         "CSC",
@@ -92,137 +124,122 @@ def main():
         "LAR",
         "MCC",
         "MIC",
+        "MP",
         "MPC",
         "MTC",
         "OUT",
         "PHI",
         "PPB",
         "PPI",
+        "QRC",
+        "RA",
         "RAS",
+        "RHE",
         "SOD",
         "STC",
         "SUN",
+        "TV",
         "UTV",
         "WBA",
         "WEL",
         "WIF",
     ]
 
-    logging.info(f"Processing {len(report_data_966)} 966 bookplates")
-    errored_holdings_count = 0
-    updated_holdings_count = 0
-    skipped_holdings_count = 0
+    remove_bookplates(report_data_856, "856", client)
+    remove_bookplates(report_data_966, "966", client, bookplates_to_leave_966)
 
-    for index, item in enumerate(report_data_966):
-        mms_id = item["MMS Id"]
-        holding_id = item["Holding Id"]
-
-        alma_holding = client.get_holding(mms_id, holding_id).get("content")
-        # make sure we got a valid bib
-        if (
-            b"is not valid" in alma_holding
-            or b"INTERNAL_SERVER_ERROR" in alma_holding
-            or b"Search failed" in alma_holding
-            or alma_holding is None
-        ):
-            logging.error(
-                f"Error finding MMS ID {mms_id}, Holding ID {holding_id}. Skipping this record."
-            )
-            errored_holdings_count += 1
-
-        else:
-            # convert to Pymarc to handle fields and subfields
-            pymarc_record = get_pymarc_record_from_bib(alma_holding)
-            pymarc_966s = pymarc_record.get_fields("966")
-            if not pymarc_966s:
-                logging.info(
-                    f"No 966 found for MMS ID {mms_id}, Holding ID {holding_id}"
-                )
-                skipped_holdings_count += 1
-            else:
-                for field_966 in pymarc_966s:
-                    if needs_966_removed(field_966, bookplates_to_leave_966):
-                        pymarc_record.remove_field(field_966)
-                        logging.info(
-                            f"Removing 966 bookplate from MMS ID {mms_id}, Holding ID {holding_id}"
-                        )
-                    else:
-                        logging.info(
-                            f"Not removing 966 bookplate from MMS ID {mms_id}, ",
-                            f"Holding ID {holding_id}",
-                        )
-                # convert back to Alma Holding and send update
-                new_alma_holding = prepare_bib_for_update(alma_holding, pymarc_record)
-                client.update_holding(mms_id, holding_id, new_alma_holding)
-                updated_holdings_count += 1
-    logging.info("966 Bookplates Updated")
-    logging.info(f"Total Holdings Updated: {updated_holdings_count}")
-    logging.info(f"Total Holdings Skipped: {skipped_holdings_count}")
-    logging.info(f"Total Holdings Errored: {errored_holdings_count}")
-
-    logging.info(f"Processing {len(report_data_856)} 856 bookplates")
-    errored_holdings_count = 0
-    updated_holdings_count = 0
-    skipped_holdings_count = 0
-    for index, item in enumerate(report_data_856):
-        mms_id = item["MMS Id"]
-        holding_id = item["Holding Id"]
-
-        alma_holding = client.get_holding(mms_id, holding_id).get("content")
-        # make sure we got a valid bib
-        if (
-            b"is not valid" in alma_holding
-            or b"INTERNAL_SERVER_ERROR" in alma_holding
-            or b"Search failed" in alma_holding
-            or alma_holding is None
-        ):
-            logging.error(
-                f"Error finding MMS ID {mms_id}, Holding ID {holding_id}. Skipping this record."
-            )
-            errored_holdings_count += 1
-        else:
-            # convert to Pymarc to handle fields and subfields
-            pymarc_record = get_pymarc_record_from_bib(alma_holding)
-            pymarc_856s = pymarc_record.get_fields("856")
-            if not pymarc_856s:
-                logging.info(
-                    f"No 856 found for MMS ID {mms_id}, Holding ID {holding_id}"
-                )
-                skipped_holdings_count += 1
-            else:
-                for field_856 in pymarc_856s:
-                    if needs_856_removed(field_856):
-                        pymarc_record.remove_field(field_856)
-                        logging.info(
-                            f"Removing 856 bookplate from MMS ID {mms_id}, Holding ID {holding_id}"
-                        )
-                    else:
-                        logging.info(
-                            f"Not removing 856 bookplate from MMS ID {mms_id}, ",
-                            f"Holding ID {holding_id}",
-                        )
-                # convert back to Alma Holding and send update
-                new_alma_holding = prepare_bib_for_update(alma_holding, pymarc_record)
-                client.update_holding(mms_id, holding_id, new_alma_holding)
-                updated_holdings_count += 1
-    logging.info("856 Bookplates Updated")
-    logging.info(f"Total Holdings Updated: {updated_holdings_count}")
-    logging.info(f"Total Holdings Skipped: {skipped_holdings_count}")
-    logging.info(f"Total Holdings Errored: {errored_holdings_count}")
     logging.info("Script Complete")
 
 
+def remove_bookplates(
+    report_data: list,
+    marc_field_number: str,
+    client: AlmaAPIClient,
+    bookplates_to_leave: Optional[list] = [],
+):
+    logging.info(f"Processing {len(report_data)} {marc_field_number} bookplates")
+    errored_holdings_count = 0
+    updated_holdings_count = 0
+    skipped_holdings_count = 0
+    for index, item in enumerate(report_data):
+        logging.info(f"Current {marc_field_number} report index: {index}")
+        mms_id = item["MMS Id"]
+        holding_id = item["Holding Id"]
+
+        alma_holding = client.get_holding(mms_id, holding_id).get("content")
+        # make sure we got a valid bib
+        if (
+            b"is not valid" in alma_holding
+            or b"INTERNAL_SERVER_ERROR" in alma_holding
+            or b"Search failed" in alma_holding
+            or alma_holding is None
+        ):
+            logging.error(
+                f"Error finding MMS ID {mms_id}, Holding ID {holding_id}. Skipping this record."
+            )
+            errored_holdings_count += 1
+
+        else:
+            # convert to Pymarc to handle fields and subfields
+            pymarc_record = get_pymarc_record_from_bib(alma_holding)
+            pymarc_fields = pymarc_record.get_fields(marc_field_number)
+            if not pymarc_fields:
+                logging.info(
+                    f"No {marc_field_number} found for MMS ID {mms_id}, Holding ID {holding_id}"
+                )
+                skipped_holdings_count += 1
+            else:
+                for pymarc_field in pymarc_fields:
+                    # if this is the 966 field, check if it needs to be removed
+                    # based on bookplates_to_leave
+                    if marc_field_number == "966":
+                        if needs_966_removed(pymarc_field, bookplates_to_leave):
+                            pymarc_record.remove_field(pymarc_field)
+                            logging.info(
+                                f"Removing 966 bookplate from MMS ID {mms_id}, "
+                                f"Holding ID {holding_id}"
+                            )
+                        else:
+                            logging.info(
+                                f"Not removing 966 bookplate from MMS ID {mms_id}, "
+                                f"Holding ID {holding_id}",
+                            )
+                    # if this is the 856 field, check if it needs to be removed
+                    # based on the presence of "Bookplate"
+                    elif marc_field_number == "856":
+                        if needs_856_removed(pymarc_field):
+                            pymarc_record.remove_field(pymarc_field)
+                            logging.info(
+                                f"Removing 856 bookplate from MMS ID {mms_id}, "
+                                f"Holding ID {holding_id}"
+                            )
+                        else:
+                            logging.info(
+                                f"Not removing 856 bookplate from MMS ID {mms_id}, "
+                                f"Holding ID {holding_id}",
+                            )
+                # convert back to Alma Holding and send update
+                new_alma_holding = prepare_bib_for_update(alma_holding, pymarc_record)
+                client.update_holding(mms_id, holding_id, new_alma_holding)
+                updated_holdings_count += 1
+    logging.info(f"{marc_field_number} Bookplates Updated")
+    logging.info(f"Total Holdings Updated: {updated_holdings_count}")
+    logging.info(f"Total Holdings Skipped: {skipped_holdings_count}")
+    logging.info(f"Total Holdings Errored: {errored_holdings_count}")
+
+
 def needs_966_removed(field_966: Field, bookplates_to_leave: list) -> bool:
-    # only remove 966s that don't contain any of the SPACs in bookplates_to_leave
+    # only remove 966s that don't contain any of the SPACs in bookplates_to_leave in $a
     for term in bookplates_to_leave:
-        if term in field_966.format_field():
+        if term in field_966.get_subfields("a"):
+            logging.info(f"Found {term} in 966 field")
             return False
     return True
 
 
 def needs_856_removed(field_856: Field) -> bool:
-    # only remove 856s that contain "Bookplate"
-    if "Bookplate" in field_856.format_field():
+    # only remove 856s that contain "Bookplate" in $3
+    if "Bookplate" in field_856.get_subfields("3"):
         return True
     return False
 

--- a/remove_bookplates_one_time.py
+++ b/remove_bookplates_one_time.py
@@ -95,12 +95,12 @@ def remove_bookplates(
                         pymarc_record.remove_field(field_856)
                         logging.info(
                             f"Removing 856 bookplate from MMS ID {mms_id}, "
-                            f"Holding ID {holding_id} ($a: {field_856.get_subfields('a')})"
+                            f"Holding ID {holding_id} ($z: {field_856.get_subfields('z')})"
                         )
                     else:
                         logging.info(
                             f"Not removing 856 bookplate from MMS ID {mms_id}, "
-                            f"Holding ID {holding_id} ($a: {field_856.get_subfields('a')})",
+                            f"Holding ID {holding_id} ($z: {field_856.get_subfields('z')})",
                         )
 
                 # check if any changes were made

--- a/remove_bookplates_one_time.py
+++ b/remove_bookplates_one_time.py
@@ -83,24 +83,24 @@ def remove_bookplates(
                         pymarc_record.remove_field(field_966)
                         logging.info(
                             f"Removing 966 bookplate from MMS ID {mms_id}, "
-                            f"Holding ID {holding_id}"
+                            f"Holding ID {holding_id} ($a: {field_966.get_subfields('a')})"
                         )
                     else:
                         logging.info(
                             f"Not removing 966 bookplate from MMS ID {mms_id}, "
-                            f"Holding ID {holding_id}",
+                            f"Holding ID {holding_id} ($a: {field_966.get_subfields('a')})",
                         )
                 for field_856 in pymarc_856_fields:
                     if needs_856_removed(field_856):
                         pymarc_record.remove_field(field_856)
                         logging.info(
                             f"Removing 856 bookplate from MMS ID {mms_id}, "
-                            f"Holding ID {holding_id}"
+                            f"Holding ID {holding_id} ($a: {field_856.get_subfields('a')})"
                         )
                     else:
                         logging.info(
                             f"Not removing 856 bookplate from MMS ID {mms_id}, "
-                            f"Holding ID {holding_id}",
+                            f"Holding ID {holding_id} ($a: {field_856.get_subfields('a')})",
                         )
 
                 # check if any changes were made

--- a/remove_bookplates_one_time.py
+++ b/remove_bookplates_one_time.py
@@ -37,7 +37,11 @@ def get_966_report(analytics_api_key: str) -> list:
 
 def main():
     parser = argparse.ArgumentParser()
-    parser.add_argument("environment", help="Alma environment (sandbox or production)")
+    parser.add_argument(
+        "environment",
+        choices=["sandbox", "production"],
+        help="Alma environment (sandbox or production)",
+    )
     parser.add_argument(
         "--log-level",
         choices=["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"],
@@ -230,17 +234,21 @@ def remove_bookplates(
 
 def needs_966_removed(field_966: Field, bookplates_to_leave: list) -> bool:
     # only remove 966s that don't contain any of the SPACs in bookplates_to_leave in $a
+    subfields = field_966.get_subfields("a")
     for term in bookplates_to_leave:
-        if term in field_966.get_subfields("a"):
-            logging.info(f"Found {term} in 966 field")
-            return False
+        for subfield in subfields:
+            if term in subfield:
+                logging.info(f"Found {term} in 966 field")
+                return False
     return True
 
 
 def needs_856_removed(field_856: Field) -> bool:
     # only remove 856s that contain "Bookplate" in $3
-    if "Bookplate" in field_856.get_subfields("3"):
-        return True
+    subfields = field_856.get_subfields("3")
+    for subfield in subfields:
+        if "Bookplate" in subfield:
+            return True
     return False
 
 


### PR DESCRIPTION
Implements [SYS-1567](https://uclalibrary.atlassian.net/browse/SYS-1567)

After our project to add bookplate information into bib records to make them visible in Primo, we want to clean up old bookplates information in holdings records. In particular, this script is intended to delete the following "bookplates" fields from holdings records:
1. 856 fields that contain the string "Bookplate" in $3
2. 966 fields that _do not_ contain one of the FTVA SPACs to preserve (lines 97-147 in the script).

This script relies on two analytics reports, one for 856s and one for 966s. These reports do some basic filtering to check if the "Bookplate" string or the SPACs (respectively) are present anywhere in the field. The script confirms the removal conditions in the specific subfields in `needs_856_removed()` and `needs_966_removed()`.

Currently, the 966 report returns about 300,000 holdings to update, and the 856 report returns about 50,000.

The script takes the following arguments:
* `environment`: `sandbox` or `production`. Production data is used for the reports regardless.
* `--start-index-966-report`: Optional, defaults to 0. Begins processing the 966 report data at the specified index.
* `--start-index-856-report`: Optional, defaults to 0. Begins processing the 856 report data at the specified index.
* `--limit`: Optional, defaults to None. Sets a limit on the number of items processed (applied to both reports) - useful for testing.

If testing in the sandbox, using a `start-index` >= 160 should get you data that I haven't touched yet.

[SYS-1567]: https://uclalibrary.atlassian.net/browse/SYS-1567?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ