### PR TITLE
SYS-1718: handle exceptions in remove bookplates script

### DIFF
--- a/remove_bookplates_one_time.py
+++ b/remove_bookplates_one_time.py
@@ -8,6 +8,9 @@ from alma_api_client import (
     AlmaAnalyticsClient,
 )
 from pymarc import Field
+from datetime import datetime
+from retry.api import retry_call
+import json
 
 
 def get_bookplates_report(analytics_api_key: str) -> list:
@@ -43,18 +46,36 @@ def needs_856_removed(field_856: Field) -> bool:
 
 
 def remove_bookplates(
-    report_data: list, client: AlmaAPIClient, bookplates_to_leave: list
+    report_data: list,
+    client: AlmaAPIClient,
+    bookplates_to_leave: list,
+    start_index: int = 0,
 ):
     logging.info(f"Processing {len(report_data)} bookplates")
     errored_holdings_count = 0
     updated_holdings_count = 0
     skipped_holdings_count = 0
+    errored_holdings = []
     for index, item in enumerate(report_data):
-        logging.info(f"Current report index: {index}")
+        logging.info(f"Current report index: {index + start_index}")
         mms_id = item["MMS Id"]
         holding_id = item["Holding Id"]
-
-        alma_holding = client.get_holding(mms_id, holding_id).get("content")
+        try:
+            alma_holding_record = retry_call(
+                client.get_holding,
+                fargs=(mms_id, holding_id),
+                tries=3,
+                delay=20,
+                backoff=2,
+            )
+        except Exception as e:
+            logging.error(
+                f"Error finding MMS ID {mms_id}, Holding ID {holding_id}: {e}"
+            )
+            errored_holdings_count += 1
+            errored_holdings.append({"MMS Id": mms_id, "Holding Id": holding_id})
+            continue
+        alma_holding = alma_holding_record.get("content")
         # make sure we got a valid bib
         if (
             b"is not valid" in alma_holding
@@ -66,6 +87,7 @@ def remove_bookplates(
                 f"Error finding MMS ID {mms_id}, Holding ID {holding_id}. Skipping this record."
             )
             errored_holdings_count += 1
+            errored_holdings.append({"MMS Id": mms_id, "Holding Id": holding_id})
 
         else:
             # convert to Pymarc to handle fields and subfields
@@ -114,12 +136,42 @@ def remove_bookplates(
                     new_alma_holding = prepare_bib_for_update(
                         alma_holding, pymarc_record
                     )
-                    client.update_holding(mms_id, holding_id, new_alma_holding)
-                    updated_holdings_count += 1
+                    # deal with possible ConnectTimeout error
+                    try:
+                        retry_call(
+                            client.update_holding,
+                            fargs=(mms_id, holding_id, new_alma_holding),
+                            tries=3,
+                            delay=20,
+                            backoff=2,
+                        )
+                        client.update_holding(mms_id, holding_id, new_alma_holding)
+                    except Exception as e:
+                        logging.error(
+                            f"Error updating MMS ID {mms_id}, Holding ID {holding_id}: {e}"
+                        )
+                        errored_holdings_count += 1
+                        errored_holdings.append(
+                            {"MMS Id": mms_id, "Holding Id": holding_id}
+                        )
+                    else:
+
+                        logging.info(
+                            f"Updated MMS ID {mms_id}, Holding ID {holding_id}"
+                        )
+                        updated_holdings_count += 1
     logging.info("Finished Bookplate Updates")
     logging.info(f"Total Holdings Updated: {updated_holdings_count}")
     logging.info(f"Total Holdings Skipped: {skipped_holdings_count}")
     logging.info(f"Total Holdings Errored: {errored_holdings_count}")
+    if errored_holdings:
+        logging.info(f"Errored Holdings: {errored_holdings}")
+        # write errored holdings to file
+        output_filename = (
+            f"errored_holdings_{datetime.now().strftime('%Y%m%d_%H%M%S')}.json"
+        )
+        with open(output_filename, "w") as f:
+            json.dump(errored_holdings, f)
 
 
 def main():
@@ -147,9 +199,17 @@ def main():
         default=None,
         help="Limit the number of records to process",
     )
+    parser.add_argument(
+        "--local-report-data-path",
+        type=str,
+        default=None,
+        help="Path to local report data file, to use instead of fetching from analytics",
+    )
     args = parser.parse_args()
 
-    logging.basicConfig(filename="remove_bookplates_one_time.log", level=args.log_level)
+    logging_datetime = datetime.now().strftime("%Y%m%d_%H%M%S")
+    base_filename = f"remove_bookplates_{logging_datetime}"
+    logging.basicConfig(filename=f"{base_filename}.log", level=args.log_level)
     # always suppress urllib3 logs with lower level than WARNING
     logging.getLogger("urllib3").setLevel(logging.WARNING)
 
@@ -162,11 +222,15 @@ def main():
         analytics_api_key = API_KEYS["DIIT_ANALYTICS"]
         alma_api_key = API_KEYS["DIIT_SCRIPTS"]
 
-    logging.info("Getting bookplate report data")
-    report_data = get_bookplates_report(analytics_api_key)
+    if args.local_report_data_path:
+        logging.info(f"Using local report data from {args.local_report_data_path}")
+        with open(args.local_report_data_path, "r") as f:
+            report_data = json.load(f)[args.start_index :]
 
-    # start at index specified in args
-    report_data = report_data[args.start_index :]
+    else:
+        logging.info("Getting bookplate report data")
+        report_data = get_bookplates_report(analytics_api_key)
+        report_data = report_data[args.start_index :]
 
     # if a limit is specified, only process that many records
     if args.limit:
@@ -226,7 +290,7 @@ def main():
         "WIF",
     ]
 
-    remove_bookplates(report_data, client, bookplates_to_leave_966)
+    remove_bookplates(report_data, client, bookplates_to_leave_966, args.start_index)
 
 
 if __name__ == "__main__":

--- a/remove_bookplates_one_time.py
+++ b/remove_bookplates_one_time.py
@@ -239,7 +239,6 @@ def main():
     else:
         logging.info("Getting bookplate report data")
         report_data = get_bookplates_report(analytics_api_key)
-        report_data = report_data
 
     client = AlmaAPIClient(alma_api_key)
 


### PR DESCRIPTION
Implements [SYS-1718](https://uclalibrary.atlassian.net/browse/SYS-1718)

Uses the `retry` package to retry failed calls when retrieving and updating Alma holdings records. Calls are tried up to three times, with a 20s delay and 2x backoff.

Exceptions are now handled for these calls if the retries do not work. Holdings resulting in exceptions are logged with Error messages in the log file, and are also written to a new output file (`errored_holdings_{datetime}.json`). This new output file can be used together with the new optional command-line argument `--local-report-data-path` to rerun only the errored holdings.

Log files now also include a timestamp in the filename. Logging is also updated to show the correct cumulative report index (see line 60).

To support these changes, `retry`, `datetime` and `json` are added as new dependencies. 

[SYS-1718]: https://uclalibrary.atlassian.net/browse/SYS-1718?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ