### PR TITLE
SYS-1819: Update invoice job name

### DIFF
--- a/process_invoices.py
+++ b/process_invoices.py
@@ -32,7 +32,7 @@ def get_invoice_job_id(profile_id):
     # jobs is a dictionary, with 'job' list of dictionaries and 'total_record_count' (int)
     job_id = None
     for job in jobs["job"]:
-        if job["description"] == "Exports invoices to ERP system":
+        if job["description"] == "Exports invoices to ERP system (PA)":
             job_id = job["id"]
     if job_id is not None:
         print(f"job_id: {job_id}")


### PR DESCRIPTION
Fixes [SYS-1819](https://uclalibrary.atlassian.net/browse/SYS-1819).

Starting 5/2/2025, the value of the description field changed for the Alma job which exports our invoices.  This does not seem to be available via the Alma UI, and I don't know why it changed.  Since we use the description to identify the right job to run, this broke our export script.

I updated the description in code.


[SYS-1819]: https://uclalibrary.atlassian.net/browse/SYS-1819?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ