### PR TITLE
SYS-2021: Update `remove_bookplates_one_time.py` to use new `AlmaAPIClient`

### DIFF
--- a/remove_bookplates_one_time.py
+++ b/remove_bookplates_one_time.py
@@ -3,8 +3,6 @@ import logging
 from alma_api_keys import API_KEYS
 from alma_api_client import (
     AlmaAPIClient,
-    get_pymarc_record_from_bib,
-    prepare_bib_for_update,
     AlmaAnalyticsClient,
 )
 from pymarc import Field
@@ -17,6 +15,11 @@ from requests.exceptions import ConnectTimeout
 
 
 def get_bookplates_report(analytics_api_key: str) -> list:
+    """Get the bookplates report from Alma Analytics.
+
+    :param analytics_api_key: Alma Analytics API key
+    :return: Bookplates report data
+    """
     # analytics only available in prod environment
     aac = AlmaAnalyticsClient(analytics_api_key)
     report_path = (
@@ -29,6 +32,12 @@ def get_bookplates_report(analytics_api_key: str) -> list:
 
 
 def needs_966_removed(field_966: Field, bookplates_to_leave: list) -> bool:
+    """Determine if a 966 field needs to be removed.
+
+    :param field_966: 966 field to test
+    :param bookplates_to_leave: List of bookplates to leave
+    :return: True if the 966 field needs to be removed, False otherwise
+    """
     # only remove 966s that don't contain any of the SPACs in bookplates_to_leave in $a
     subfields = field_966.get_subfields("a")
     for term in bookplates_to_leave:
@@ -40,6 +49,11 @@ def needs_966_removed(field_966: Field, bookplates_to_leave: list) -> bool:
 
 
 def needs_856_removed(field_856: Field) -> bool:
+    """Determine if a 856 field needs to be removed.
+
+    :param field_856: 856 field to test
+    :return: True if the 856 field needs to be removed, False otherwise
+    """
     # only remove 856s that contain "Bookplate" in $3
     subfields = field_856.get_subfields("3")
     for subfield in subfields:
@@ -55,6 +69,14 @@ def remove_bookplates(
     start_index: int = 0,
     limit: int = None,
 ):
+    """Remove bookplates from Alma holdings records.
+
+    :param report_data: Bookplate report data
+    :param client: Alma API client
+    :param bookplates_to_leave: List of bookplates to leave
+    :param start_index: Start index for the report data
+    :param limit: Limit the number of records to process
+    """
     # slice the report data to specified start index and limit
     report_data = report_data[start_index:]
     if limit:
@@ -184,6 +206,7 @@ def remove_bookplates(
 
 
 def main():
+    """Entry point for the script."""
     parser = argparse.ArgumentParser()
     parser.add_argument(
         "environment",

--- a/remove_bookplates_one_time.py
+++ b/remove_bookplates_one_time.py
@@ -36,13 +36,13 @@ def _get_arguments() -> argparse.Namespace:
         help="Path to the configuration file with API keys",
     )
     parser.add_argument(
-        "--log-level",
+        "--log_level",
         choices=["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"],
         default="INFO",
         help="Set the logging level",
     )
     parser.add_argument(
-        "--start-index",
+        "--start_index",
         type=int,
         default=0,
         help="Start index for the bookplates report",
@@ -213,6 +213,7 @@ def remove_bookplates(
             continue
         alma_holding_xml = alma_holding_record.alma_xml
         # make sure we got a valid holding record
+        # TODO: use built-in error handling here, when it's added to the new Alma API client
         if (
             b"is not valid" in alma_holding_xml
             or b"INTERNAL_SERVER_ERROR" in alma_holding_xml
@@ -324,8 +325,10 @@ def main():
     _configure_logging(args.log_level)
 
     if args.production:
+        logging.info("Using production Alma API key")
         alma_api_key = config["alma_api_keys"]["DIIT_SCRIPTS"]
     else:  # default to sandbox
+        logging.info("Using sandbox Alma API key")
         alma_api_key = config["alma_api_keys"]["SANDBOX"]
 
     # analytics only available in prod environment


### PR DESCRIPTION
Implements [SYS-2021](https://uclalibrary.atlassian.net/browse/SYS-2021)

### Acceptance criteria
- [X] `remove_bookplates_one_time.py` is updated to work with our new Alma API client package
- [X] All errors and warnings from `pylance` are resolved
- [X] All methods have updated doc-strings using our current format
- [X] Replace dependencies on `alma_api_keys.py` with a single command-line parameter for --api_key, or --config_file imported via TOML, using `_get_arguments()` and `_get_config()` as appropriate

### Description
This PR updates the `remove_bookplates_one_time.py` script to use our new Alma API client package, and to bring the script in line with our current best-practices. The core functionality of the script remains the same: checking Alma holding records for bookplate information in certain sub-field, then removing that info as necessary.

Logging is refactored to use a helper method and to output to a `logs` sub-directory in the project folder. Loading of API keys is also refactored to use a TOML config file, which I'll send separately. Input data with `mms_id` and `holding_id` can be provided via a CSV Alma report file now, in addition to the JSON format originally supported. I will also send this data file separately.

One change of note to the CLI arguments is that the `--environment` flag, which previously accepted a choice of either "sandbox" or "production", is now a `--production` flag, which is a boolean that will cause the script to load the production API key from the config file; without the `--production` flag, the script defaults to the sandbox key.

### Testing
There were no existing unit tests, so I didn't add any at this point, but can do if needed. For testing, I used the CSV Alma report that @ztucker4 provided as an input file and set the `--limit` parameter to a low number. I ran the script using the sandbox API key, which gave me sensible results. I'd suggest running the script with the following arguments, to start at an index that hasn't already been updated in the sandbox:

`python remove_bookplates_one_time.py --log-level DEBUG --report_file {INPUT_CSV} --start_index 5 --limit 5`



[SYS-2021]: https://uclalibrary.atlassian.net/browse/SYS-2021?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ