### PR TITLE
SYS-2024: Update CAIA request export script with new API package

### DIFF
--- a/export_requests_to_caia.py
+++ b/export_requests_to_caia.py
@@ -1,65 +1,181 @@
-#!/usr/bin/env python3
-"""
-Finds and runs an Alma job to export remote storage requests.
-See LICENSE.txt in this repository.
-"""
+import argparse
+import tomllib
 from datetime import datetime
-from typing import Type
-from alma_api_client import AlmaAPIClient
-from alma_api_keys import API_KEYS
+from alma_api_client import APIError, APIResponse, AlmaAPIClient
 
 
-def get_profile_id(profile_name: str, alma_client: Type[AlmaAPIClient]) -> str:
+def _get_arguments() -> argparse.Namespace:
+    """Parse command-line arguments.
+
+    :return: Parsed arguments for program as a Namespace object.
     """
-    Given an Alma integration profile name (or word from the name),
-        return the profile id configured for remote storage.
+    parser = argparse.ArgumentParser(description="Update bookplates in Alma.")
+    parser.add_argument(
+        "--production",
+        action="store_true",
+        help="Use production Alma API key. Default is sandbox.",
+    )
+    parser.add_argument(
+        "--config_file",
+        type=str,
+        default="secret_config.toml",
+        help="Path to config file with API keys",
+    )
+    parser.add_argument(
+        "--log_level",
+        choices=["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"],
+        default="INFO",
+        help="Set the logging level",
+    )
+    return parser.parse_args()
+
+
+def _get_config(config_file_name: str) -> dict:
+    """Returns configuration for this program, loaded from TOML file.
+
+    :param config_file_name: Path to the configuration file.
+    :return: Configuration dictionary.
     """
-    profile_id: str = None
-    parameters: dict = {"q": "name~Caiasoft"}
-    profiles = alma_client.get_integration_profiles(parameters)
-    # Find the first profile which is REMOTE_STORAGE
-    for profile in profiles["integration_profile"]:
-        if profile["type"]["value"] == "REMOTE_STORAGE":
-            profile_id = profile["id"]
+    with open(config_file_name, "rb") as f:
+        config = tomllib.load(f)
+    return config
+
+
+def _get_profile_id(api_response: APIResponse) -> str:
+    """Return the Alma profile id from an Alma API response.
+
+    :param api_response: An Alma `APIResponse` containing integration profile data.
+    :raises: `ValueError`, if the response has other than one single profile
+    or no id is found in the profile data.
+    :return profile_id: The matching integration profile id.
+    """
+    api_data = api_response.api_data
+    total_record_count = api_data.get("total_record_count", 0)
+    if total_record_count == 1:
+        profiles = api_data.get("integration_profile", [])
+        # 1 profile (trust the count), get its id.
+        profile_id = profiles[0].get("id", "")
+        if profile_id:
+            return profile_id
+        else:
+            raise ValueError("Profile id missing from profile")
+    else:
+        raise ValueError(f"Expected 1 profile, found: {total_record_count}")
+
+
+def _get_job_id(api_response: APIResponse, job_name: str) -> str:
+    """Return the Alma job id from an Alma API response, matching the expected job name
+    in case multiple jobs were found.
+
+    :param api_response: An Alma `APIResponse` containing job data.
+    :raises: `ValueError`, if no id is found in the job data.
+    :return job_id: The matching job id.
+    """
+    # Initialize, in case there are no jobs in the API data at all.
+    job_id = ""
+    # Profiles can have many jobs associated with them.
+    # Find first job which matches the expected job name.
+    # This is fragile since the job name could be changed in Alma, but the best option available.
+    for job in api_response.api_data.get("job", []):
+        if job.get("name", "") == job_name:
+            job_id = job.get("id", "")
             break
-    return profile_id
-
-
-def get_job_id(profile_id: str, alma_client: Type[AlmaAPIClient]) -> str:
-    """
-    Given an Alma integration profile id, return the job id for sending remote storage requests.
-    """
-    job_id: str = None
-    parameters: dict = {"type": "SCHEDULED", "profile_id": profile_id}
-    jobs = alma_client.get_jobs(parameters)
-    # Find the first job which is FULFILLMENT
-    for job in jobs["job"]:
-        if job["category"]["value"] == "FULFILLMENT":
-            job_id = job["id"]
-            break
-    return job_id
-
-
-def run_job(job_id: str, alma_client: Type[AlmaAPIClient]) -> None:
-    """
-    Given an Alma job id, run the job.
-    """
-    data = {}
-    params = {"op": "run"}
-    alma_client.run_job(job_id, data, params)
+    # Found one, return it.
+    if job_id:
+        return job_id
+    else:
+        raise ValueError(f"No job found in API data for {job_name}")
 
 
 def main():
-    alma_client = AlmaAPIClient(API_KEYS["CAIA_INTERNAL"])
-    # Change profile_name as needed for search to work in your Alma instance
-    profile_name = "Caiasoft"
-    profile_id = get_profile_id(profile_name, alma_client)
-    if profile_id:
-        job_id = get_job_id(profile_id, alma_client)
-    if job_id:
-        now = datetime.now().strftime("%c")
-        print(f"Running job {job_id} at {now}")
-        run_job(job_id, alma_client)
+    """Entry point for the script.
+
+    This script runs an Alma job associated with the Caiasoft remote storage integration
+    profile, "Send data from Alma to Caiasoft via SFTP".  When there are appropriate requests
+    in Alma, this job causes data for them to be exported and uploaded to Caia's SFTP server
+    (connection handled within Alma, not by this script).
+
+    The script does not wait for the job to complete.  Experiments show that checking the job
+    info after completion, like /almaws/v1/conf/jobs/S6378570160006533/instances/25701065310006533,
+    does not contain useful data, though there may be events associated with the job we could
+    check for.
+    """
+    args = _get_arguments()
+    config = _get_config(args.config_file)
+
+    if args.production:
+        alma_api_key = config["alma_api_keys"]["DIIT_SCRIPTS"]
+    else:  # default to sandbox
+        print("This job should not be run in the SANDBOX environment;")
+        print("behavior is unknown, but could upload duplicate / wrong")
+        print("requests to Caia. Exiting now.")
+        exit()
+
+    client = AlmaAPIClient(alma_api_key)
+
+    # Initialize variables to make type-checker happy.
+    profile_id = ""
+    job_id = ""
+
+    # Hard-coded integration profile code, should be unique;
+    # not using hard-coded profile id, in case that's subject to change.
+    profile_code = "Caiasoft"
+    profile_parameters = {"q": f"code~{profile_code}"}
+    # If one single profile is not found, no point in continuing. Catch exceptions
+    # to print error messages, then exit.
+    try:
+        # No APIError raised if nothing found (no 400 or 404), just a response with
+        # {'total_record_count': 0}.
+        api_response = client.get_integration_profiles(parameters=profile_parameters)
+        profile_id = _get_profile_id(api_response)
+    except APIError as e:
+        # Print detailed error messages from API response.
+        print(e.error_messages)
+        exit()
+    except ValueError as e:
+        print(e)
+        exit()
+
+    # An empty profile_id, if the profile wasn't found and somehow not detected already,
+    # can retrieve multiple irrelevant jobs, leading to problems.
+    assert profile_id != ""
+
+    # We've got one real profile id, so try to find the job we need.
+    job_parameters = {
+        "category": "FULFILLMENT",
+        "profile_id": profile_id,
+        "type": "SCHEDULED",
+    }
+    try:
+        api_response = client.get_jobs(parameters=job_parameters)
+        # Jobs cannot be filtered on name via API, so use
+        # job name as secondary check.
+        job_name = "Send Requests to Remote Storage"
+        job_id = _get_job_id(api_response, job_name)
+    except APIError as e:
+        # Print detailed error messages from API response.
+        print(e.error_messages)
+        exit()
+    except ValueError as e:
+        print(e)
+        exit()
+
+    # Still paranoid.
+    assert job_id != ""
+
+    # We've got a real job id, so try to run it.
+    now = datetime.now().strftime("%c")
+    print(f"Running job {job_id} at {now}")
+    # Run the job, but no need to wait for completion.
+    # TODO: Consider implementing API call for "Retrieve Job Instance Event Details",
+    # which can provide useful info when the job does complete.
+    try:
+        run_parameters = {"op": "run"}
+        client.run_job(job_id, parameters=run_parameters)
+    except APIError as e:
+        # Print detailed error messages from API response.
+        print(e.error_messages)
+        exit()
 
 
 if __name__ == "__main__":

--- a/export_requests_to_caia.py
+++ b/export_requests_to_caia.py
@@ -9,7 +9,7 @@ def _get_arguments() -> argparse.Namespace:
 
     :return: Parsed arguments for program as a Namespace object.
     """
-    parser = argparse.ArgumentParser(description="Update bookplates in Alma.")
+    parser = argparse.ArgumentParser(description="Run Caia request export job.")
     parser.add_argument(
         "--production",
         action="store_true",
@@ -20,12 +20,6 @@ def _get_arguments() -> argparse.Namespace:
         type=str,
         default="secret_config.toml",
         help="Path to config file with API keys",
-    )
-    parser.add_argument(
-        "--log_level",
-        choices=["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"],
-        default="INFO",
-        help="Set the logging level",
     )
     return parser.parse_args()
 


### PR DESCRIPTION
Implements [SYS-2024](https://uclalibrary.atlassian.net/browse/SYS-2024).

This PR updates the `export_requests_to_caia.py` script:
* Use our Alma API package, latest version (0.2.0)
* Add common config and arguments helpers
  * Note: I did not add logging, as this script runs frequently via cron and I want all output to go into a log file I specify in the cron job, not in code.
* Add doc-strings using our current format.
* Fix all pylance errors and warnings.

I opted to keep most program logic in `main()`, because this script does not iterate over data.  Its sole purpose is to run a specific job, though unfortunately, I've found that job ids and even integration profile ids can change, though they usually do not.  For better or worse, rather than hard-coding Alma ids in the script, I use profile codes and job names to find the correct ids at run-time, though I'm increasingly unsure that actually is better.

Regardless of method, I've been aggressive about errors (if they happen, print the info and exit the script), and even added `assert` statements in case there's a circumstance I didn't predict which lead to an empty id.  Using `assert` for those seemed slightly cleaner than `if value: else raise ValueError(Value not found)`.

This script explicitly cannot be run in the Alma Sandbox without doing some configuration changes within the Sandbox, like changing the Cais SFTP connection so nothing can accidentally be uploaded to them.  I chose to require a production API key, existing if the `--production` flag is not set.

There are no automated tests for this script. I suppose I could capture responses and write tests which assert that the structure of data within `api_response.api_data` has not changed; let me know if you think that's worth doing.

I tested manually by fuzzing the integration profile code and the job name, to confirm that appropriate errors are raised in every branch of code when testing with live APIs and the `run_job()` block disabled.

For this PR, please look mainly at the code / structure / flow / comments.  Is it appropriate, is it clear? Do I need to write tests :) ?

Unrelated, but when you do merge, if there's only one commit message please fix any typo in the Jira number (`2924` should be `2024`, noticed after I pushed).

[SYS-2024]: https://uclalibrary.atlassian.net/browse/SYS-2024?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ