### PR TITLE
SYS-2138: Fix UCPath query to target UCLA-specific effective dates

### DIFF
--- a/ucpath.py
+++ b/ucpath.py
@@ -16,6 +16,7 @@ with ucla_people as (
         select max(EFFDT)
         from PS_UC_EXT_SYSTEM
         where EMPLID = es.EMPLID
+        and UC_EXT_SYSTEM = 'UCLA_UID'
         and BUSINESS_UNIT in ('LACMP', 'LAMED')
         and DML_IND <> 'D'
         and EFFDT <= {fn curDaTe()}


### PR DESCRIPTION
Fixes [SYS-2138](https://uclalibrary.atlassian.net/browse/SYS-2138).

This fixes a bug in our UCPath query which caused some valid UCLA employees to be excluded from selection.  The subquery which returned the latest effective date did not correctly target UCLA-specific rows, leading to possible mismatches when rows with relevant business units but not specifically UCLA UIDs were updated.

See linked ticket for full details of data review and rationale for this change.


[SYS-2138]: https://uclalibrary.atlassian.net/browse/SYS-2138?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ