### PR TITLE
DLSR-368: Handle XML entities in Alma payments file

### DIFF
--- a/make_invoice_payment_file.py
+++ b/make_invoice_payment_file.py
@@ -1,6 +1,7 @@
 import csv
 import sys
 from dateutil import parser
+from xml.sax.saxutils import escape
 
 
 def get_xml_header() -> str:
@@ -37,9 +38,10 @@ def get_xml_invoice(row: dict) -> str:
     # dict_keys(['Vendor Code', 'Invoice Number',
     # 'Invoice Date', 'Invoice Gross Amount', 'Transaction Amount',
     # 'Check Number', 'Check Date'])
-    vendor_code = row["Vendor Code"]
+    # Some fields may contain ampersands and need XML escaping.
+    vendor_code = escape(row["Vendor Code"])
     # These have trailing spaces and non-breaking spaces
-    invoice_number = row["Invoice Number"].strip()
+    invoice_number = escape(row["Invoice Number"].strip())
     invoice_date = get_yyyymmdd(row["Invoice Date"])
     check_number = row["Check Number"]
     check_date = get_yyyymmdd(row["Check Date"])


### PR DESCRIPTION
Fixes [DLSR-368](https://uclalibrary.atlassian.net/browse/DLSR-368).

This PR fixes a small bug in `make_invoice_payment_file.py`.  In rare cases, Alma vendor codes or invoice numbers can contain ampersands, which need special handling in XML and must be escaped (`&` -> `&amp;`).  There may be other such characters which can occur in this data, though none have surfaced yet.

These fields now are escaped via `xml.sax.saxutils.escape()` when the XML is assembled.


[DLSR-368]: https://uclalibrary.atlassian.net/browse/DLSR-368?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ